### PR TITLE
Allow the documentation to be built on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ repository = "https://github.com/rodrigocfd/winsafe"
 readme = "README.md"
 include = ["/src/**/*", "/Cargo.toml", "/LICENSE.md", "/README.md"]
 edition = "2018"
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"
+targets = ["aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]


### PR DESCRIPTION
Docs.rs will try to build for linux by default, which will fail for this crate since the DLLs this library binds don't exist on linux!