### PR TITLE
Add convenience method for IFile{Open,Save}Dialog

### DIFF
--- a/src/shell/com_interfaces/ifileopendialog.rs
+++ b/src/shell/com_interfaces/ifileopendialog.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use crate::co;
+use crate::{CoCreateInstance, CLSID};
 use crate::ffi_types::HRES;
 use crate::ole::decl::{ComPtr, HrResult};
 use crate::ole::privs::ok_to_hrresult;
@@ -47,6 +49,30 @@ impl ShellIFileOpenDialog for IFileOpenDialog {}
 /// [`IFileOpenDialog`](crate::IFileOpenDialog) methods from `shell` feature.
 #[cfg_attr(docsrs, doc(cfg(feature = "shell")))]
 pub trait ShellIFileOpenDialog: ShellIFileDialog {
+	/// Calls [`CoCreateInstance`](https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-cocreateinstance)
+	/// function to create a new file open dialog.
+	///
+	/// To customize CLSCTX and such, use [`CoCreateInstance`](crate::CoCreateInstance) function
+	/// directly.
+	///
+	/// # Examples
+	///
+	/// ```rust,no_run
+	/// use winsafe::prelude::*;
+	/// use winsafe::IFileOpenDialog;
+	///
+	/// let fod = IFileOpenDialog::new()?;
+	/// // setup file open dialog to your taste
+	/// let _ = fod.Show()?;
+	/// ```
+	fn new() -> HrResult<IFileOpenDialog> {
+		CoCreateInstance::<IFileOpenDialog>(
+			&CLSID::FileOpenDialog,
+			None,
+			co::CLSCTX::INPROC_SERVER,
+		)
+	}
+
 	/// [`IFileOpenDialog::GetResults`](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifileopendialog-getresults)
 	/// method.
 	///

--- a/src/shell/com_interfaces/ifilesavedialog.rs
+++ b/src/shell/com_interfaces/ifilesavedialog.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case)]
 
+use crate::co;
+use crate::{CoCreateInstance, CLSID};
 use crate::ffi_types::{BOOL, HANDLE, HRES};
 use crate::ole::decl::{ComPtr, HrResult};
 use crate::ole::privs::ok_to_hrresult;
@@ -50,6 +52,30 @@ impl ShellIFileSaveDialog for IFileSaveDialog {}
 /// [`IFileSaveDialog`](crate::IFileSaveDialog) methods from `shell` feature.
 #[cfg_attr(docsrs, doc(cfg(feature = "shell")))]
 pub trait ShellIFileSaveDialog: ShellIFileDialog {
+	/// Calls [`CoCreateInstance`](https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-cocreateinstance)
+	/// function to create a new file save dialog.
+	///
+	/// To customize CLSCTX and such, use [`CoCreateInstance`](crate::CoCreateInstance) function
+	/// directly.
+	///
+	/// # Examples
+	///
+	/// ```rust,no_run
+	/// use winsafe::prelude::*;
+	/// use winsafe::IFileSaveDialog;
+	///
+	/// let fod = IFileSaveDialog::new()?;
+	/// // setup file save dialog to your taste
+	/// let _ = fod.Show()?;
+	/// ```
+	fn new() -> HrResult<IFileSaveDialog> {
+		CoCreateInstance::<IFileSaveDialog>(
+			&CLSID::FileSaveDialog,
+			None,
+			co::CLSCTX::INPROC_SERVER,
+		)
+	}
+
 	/// [`IFileSaveDialog::SetSaveAsItem`](https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifilesavedialog-setsaveasitem)
 	/// method.
 	fn SetSaveAsItem(&self, psi: IShellItem) -> HrResult<()> {

--- a/src/shell/com_interfaces/ifilesavedialog.rs
+++ b/src/shell/com_interfaces/ifilesavedialog.rs
@@ -64,9 +64,9 @@ pub trait ShellIFileSaveDialog: ShellIFileDialog {
 	/// use winsafe::prelude::*;
 	/// use winsafe::IFileSaveDialog;
 	///
-	/// let fod = IFileSaveDialog::new()?;
+	/// let fsd = IFileSaveDialog::new()?;
 	/// // setup file save dialog to your taste
-	/// let _ = fod.Show()?;
+	/// let _ = fsd.Show()?;
 	/// ```
 	fn new() -> HrResult<IFileSaveDialog> {
 		CoCreateInstance::<IFileSaveDialog>(


### PR DESCRIPTION
might seem redundant, but this follows the case of `IShellItem::from_path`
https://github.com/rodrigocfd/winsafe/blob/c6bb0ba319be730e34cc657edebd10cdf48c0bf7/src/shell/com_interfaces/ishellitem.rs#L38-L63