### PR TITLE
Preserve comments on seq_ids

### DIFF
--- a/src/macros/seq_ids.rs
+++ b/src/macros/seq_ids.rs
@@ -26,22 +26,37 @@
 /// ```
 #[macro_export]
 macro_rules! seq_ids {
-	(
-		$name:ident = $val:expr;
-		$( $others:ident )*
-	) => {
-		pub const $name: u16 = $val;
-		seq_ids!($val + 1, $($others,)*);
-	};
+	() => {};
 
 	($val:expr,) => {};
 
-	($val:expr, $name:ident,) => {
+	(
+		$(#[$comment:meta])*
+		$name:ident = $val:expr;
+		$($rest:tt)*
+	) => {
+		$(#[$comment])*
 		pub const $name: u16 = $val;
+		seq_ids!($val + 1, $($rest)*);
 	};
 
-	($val:expr, $name:ident, $( $others:ident, )+) => {
+	($next_val:expr,
+		$(#[$comment:meta])*
+		$name:ident = $val:expr;
+		$($rest:tt)*
+	) => {
+		$(#[$comment])*
 		pub const $name: u16 = $val;
-		seq_ids!($val + 1, $($others,)*);
+		seq_ids!($val + 1, $($rest)*);
+	};
+
+	($next_val:expr,
+		$(#[$comment:meta])*
+		$name:ident
+		$($rest:tt)*
+	) => {
+		$(#[$comment])*
+		pub const $name: u16 = $next_val;
+		seq_ids!($next_val + 1, $($rest)*);
 	};
 }


### PR DESCRIPTION
Users of macro seq_ids may want to have comments on the ids. This preserves the comments on the identifiers ehen expanded by the macro.

Example usage:

```rust
seq_ids! {
    /// Foo value
    MENU_ID_FOO = 200;
    MENU_ID_BAR
    /// Baz value
    MENU_ID_BAZ
    MENU_ID_HOGE
    MENU_ID_NESTED_FOO = 300;
    MENU_ID_NESTED_BAR
}
```

Expanded:

```rust
#[doc = " Foo value"]
pub const MENU_ID_FOO: u16 = 200;
pub const MENU_ID_BAR: u16 = (200 + 1);
#[doc = " Baz value"]
pub const MENU_ID_BAZ: u16 = ((200 + 1) + 1);
pub const MENU_ID_HOGE: u16 = (((200 + 1) + 1) + 1);
pub const MENU_ID_NESTED_FOO: u16 = 300;
pub const MENU_ID_NESTED_BAR: u16 = (300 + 1);
```