### PR TITLE
bugfix: Use windows-targets crate for FFI linkage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,8 @@ user = ["kernel"]
 uxtheme = ["gdi", "ole"]
 version = ["kernel"]
 
+[dependencies]
+windows-targets = "0.48.0"
+
 # Generate docs locally:
 # RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features

--- a/src/macros/ffis.rs
+++ b/src/macros/ffis.rs
@@ -2,12 +2,16 @@
 
 /// Builds one single FFI binding function.
 macro_rules! one_func {
-	($func:ident( $( $parm:ty ),* ) -> $ret:ty) => {
-		pub(crate) fn $func( $( _: $parm, )* ) -> $ret;
+	($dll:literal $func:ident( $( $parm:ty ),* ) -> $ret:ty) => {
+		::windows_targets::link! {
+			$dll
+			"system"
+			fn $func( $( x: $parm ),* ) -> $ret
+		}
 	};
 
-	($func:ident( $( $parm:ty ),* )) => {
-		pub(crate) fn $func( $( _: $parm, )* );
+	($dll:literal $func:ident( $( $parm:ty ),* )) => {
+		one_func!($dll $func( $( $parm ),* ) -> () );
 	};
 }
 
@@ -19,11 +23,8 @@ macro_rules! extern_sys {
 			$func:ident( $( $parm:ty ),* ) $( -> $ret:ty )?
 		)*
 	) => {
-		#[link(name = $dll)]
-		extern "system" {
-			$(
-				one_func!( $func( $( $parm ),* ) $(-> $ret)? );
-			)*
-		}
+		$(
+			one_func!( $dll $func( $( $parm ),* ) $(-> $ret)? );
+		)*
 	};
 }


### PR DESCRIPTION
First off, thank you for creating this crate. It's an impressive undertaking to try to create a safe wrapper for the Windows API, especially the parts whose idioms don't translate well to Rust.

However, on a glance through the source code I noticed that FFI bindings to the Windows API are created through a naive `extern "system"` binding. This doesn't work for all targets that this crate may be used on. See [this thread](https://github.com/microsoft/windows-rs/issues/1720#issuecomment-1485373474) for more information on this problem.

This problem can be resolved through the [`windows-targets`](https://crates.io/crates/windows-targets) crate, which provides a `link!` macro that abstracts over the differences between targets. I rewrote the `extern_sys!` macro that is currently used to define the bindings to use this `link!` macro instead.

This worsens compile times (increases them by 4 seconds on my Linux machine) but I think it's worth it to use the "blessed" way of interfacing with Windows.

Also, to gush for a minute, I love that I only had to modify one macro to fix this It's a sign of a well-written crate that I didn't have to chase down the signatures for a dozen functions just to fix this.