### PR TITLE
add minimum wine compatibility in gui module

### DIFF
--- a/src/gui/window_main.rs
+++ b/src/gui/window_main.rs
@@ -118,8 +118,16 @@ impl WindowMain {
 
 		let mut b_val: BOOL = 0; // false
 		unsafe {
-			HPROCESS::GetCurrentProcess().SetUserObjectInformation( // SetTimer() safety
-				co::UOI::TIMERPROC_EXCEPTION_SUPPRESSION, &mut b_val).unwrap();
+			// SetTimer() safety
+			match HPROCESS::GetCurrentProcess().SetUserObjectInformation(
+				co::UOI::TIMERPROC_EXCEPTION_SUPPRESSION, &mut b_val) {
+				Ok(_) => {}
+				Err(ref e) if e == &co::ERROR::INVALID_PARAMETER => {
+					// https://bugs.winehq.org/show_bug.cgi?id=54951
+					// Wine doesn't support SetUserObjectInformation for now.
+				}
+				Err(e) => panic!("unexpected error: {e:?}"),
+			}
 		}
 
 		create_ui_font().unwrap();


### PR DESCRIPTION
the winsafe gui wrapper doesn't work with wine because of one unsupported api in wine so i changed the error handling to working with wine.