### PR TITLE
FIX: invalid race condition check in RegQueryValueEx

### DIFF
--- a/src/kernel/handles/hkey.rs
+++ b/src/kernel/handles/hkey.rs
@@ -1039,17 +1039,13 @@ fn validate_retrieved_reg_val(
 	data_type1: co::REG,
 	data_len1: u32,
 	data_type2: co::REG,
-	mut data_len2: u32,
+	data_len2: u32,
 	buf: Vec<u8>,
 ) -> SysResult<RegistryValue>
 {
 	if data_type1 != data_type2 {
 		// Race condition: someone modified the data type in between our calls.
 		return Err(co::ERROR::TRANSACTION_REQUEST_NOT_VALID);
-	}
-
-	if data_type1 == co::REG::SZ || data_type1 == co::REG::MULTI_SZ {
-		data_len2 += 2; // also count wchar terminating null
 	}
 
 	if data_len1 != data_len2 {


### PR DESCRIPTION
According to docs [here](https://learn.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regqueryvalueexw)

> If the data has the REG_SZ, REG_MULTI_SZ or REG_EXPAND_SZ type, this size includes any terminating null character or characters unless the data was stored without them. For more information, see Remarks.

fixes #102