### PR TITLE
Fix PFTASKDIALOGCALLBACK and TASKDIALOGCONFIG signatures.

### DIFF
--- a/src/comctl/aliases.rs
+++ b/src/comctl/aliases.rs
@@ -37,11 +37,11 @@ pub type PFNTVCOMPARE =
 pub type PFTASKDIALOGCALLBACK =
 	extern "system" fn(
 		hWnd: HWND,
-		msg: co::WM,
+		msg: co::TDN,
 		wParam: usize,
 		lParam: isize,
-		lpRefData: isize,
-	);
+		lpRefData: usize,
+	) -> co::HRESULT;
 
 /// Type alias to
 /// [`SUBCLASSPROC`](https://learn.microsoft.com/en-us/windows/win32/api/commctrl/nc-commctrl-subclassproc)

--- a/src/comctl/co.rs
+++ b/src/comctl/co.rs
@@ -2211,6 +2211,23 @@ const_bitflag! { TDF: i32;
 	SIZE_TO_CONTENT 0x0100_0000
 }
 
+const_ordinary! { TDN: u32;
+	/// [`PFTASKDIALOGCALLBACK`](crate::PFTASKDIALOGCALLBACK) `msg` (`u32`).
+	=>
+	=>
+    CREATED 0
+    NAVIGATED 1
+    BUTTON_CLICKED 2           	// wParam = Button ID
+    HYPERLINK_CLICKED 3         // lParam = (LPCWSTR)pszHREF
+    TIMER 4            			// wParam = Milliseconds since dialog created or timer reset
+    DESTROYED 5
+    RADIO_BUTTON_CLICKED 6      // wParam = Radio Button ID
+    DIALOG_CONSTRUCTED 7
+    VERIFICATION_CLICKED 8      // wParam = 1 if checkbox checked, 0 if not, lParam is unused and always 0
+    HELP 9
+    EXPANDO_BUTTON_CLICKED 10   // wParam = 0 (dialog is now collapsed), wParam != 0 (dialog is now expanded)
+}
+
 const_wm! { TRBM;
 	/// Trackbar control
 	/// [messages](https://learn.microsoft.com/en-us/windows/win32/controls/bumper-trackbar-control-reference-messages)

--- a/src/comctl/structs.rs
+++ b/src/comctl/structs.rs
@@ -1085,7 +1085,7 @@ pub struct TASKDIALOGCONFIG<'a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i, 'j> {
 	pszFooterIcon: *const u16, // union with HICON
 	pszFooter: *mut u16,
 	pub pfCallback: Option<PFTASKDIALOGCALLBACK>,
-	pub lpCallbackData: isize,
+	pub lpCallbackData: usize,
 	pub cxWidth: u32,
 
 	_pszWindowTitle: PhantomData<&'a mut u16>,


### PR DESCRIPTION
As title says. The current signature for PFTASKDIALOGCALLBACK has no return value, and the 'msg' value is a co::WM, but this is not correct. See the documentation for more details https://learn.microsoft.com/en-us/windows/win32/api/commctrl/nc-commctrl-pftaskdialogcallback