### PR TITLE
WIP: Add IPersistFile interface, and windows shortcut helper utility (Lnk)

### DIFF
--- a/src/ole/com_interfaces/ipersistfile.rs
+++ b/src/ole/com_interfaces/ipersistfile.rs
@@ -1,0 +1,79 @@
+#![allow(non_camel_case_types, non_snake_case)]
+
+use crate::co;
+use crate::decl::*;
+use crate::kernel::ffi_types::*;
+use crate::ole::privs::*;
+use crate::prelude::*;
+use crate::vt::*;
+
+/// [`IPersistFile`](crate::IPersistFile) virtual table.
+#[repr(C)]
+pub struct IPersistFileVT {
+	pub IPersistVT: IPersistVT,
+    pub IsDirty: fn(COMPTR) -> HRES,
+    pub Load: fn(COMPTR, PCSTR, u32) -> HRES,
+    pub Save: fn(COMPTR, PCSTR, i32) -> HRES,
+    pub SaveCompleted: fn(COMPTR, PCSTR) -> HRES,
+    pub GetCurFile: fn(COMPTR, PVOID) -> HRES,
+}
+
+com_interface! { IPersistFile: "0000010B-0000-0000-C000-000000000046";
+    /// [`IPersistFile`](https://learn.microsoft.com/en-us/windows/win32/api/objidl/nn-objidl-ipersistfile)
+    /// COM interface over [`IPersistFileVT`](crate::vt::IPersistFileVT).
+    ///
+    /// Automatically calls
+    /// [`Release`](https://learn.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-release)
+    /// when the object goes out of scope.
+}
+
+impl ole_IPersist for IPersistFile {}
+impl ole_IPersistFile for IPersistFile {}
+
+/// This trait is enabled with the `ole` feature, and provides methods for
+/// [`IPersistFile`](crate::IPersistFile).
+///
+/// Prefer importing this trait through the prelude:
+///
+/// ```no_run
+/// use winsafe::prelude::*;
+/// ```
+pub trait ole_IPersistFile: ole_IUnknown {
+
+    /// [`IPersistFile::IsDirty`](https://learn.microsoft.com/en-us/windows/win32/api/objidl/nf-objidl-ipersistfile-isdirty)
+    /// method.
+    #[must_use]
+    fn IsDirty(&self) -> HrResult<bool> {
+        match unsafe { co::HRESULT::from_raw((vt::<IPersistFileVT>(self).IsDirty)(self.ptr())) } {
+            co::HRESULT::S_OK => Ok(true),
+            co::HRESULT::S_FALSE => Ok(false),
+            e => Err(e),
+        }
+    }
+
+    /// [`IPersistFile::Load`](https://learn.microsoft.com/en-us/windows/win32/api/objidl/nf-objidl-ipersistfile-load)
+    /// method.
+    #[must_use]
+    fn Load(&self, file_name: &str, dw_mode: co::STGM) -> HrResult<()> {
+        ok_to_hrresult(unsafe {
+            (vt::<IPersistFileVT>(self).Load)(
+                self.ptr(),
+                WString::from_str(file_name).as_ptr(),
+                dw_mode.raw(),
+            )
+        })
+    }
+
+    /// [`IPersistFile::Save`](https://learn.microsoft.com/en-us/windows/win32/api/objidl/nf-objidl-ipersistfile-save)
+    /// method.
+    #[must_use]
+    fn Save(&self, file_name: Option<&str>, remember: bool) -> HrResult<()> {
+        ok_to_hrresult(unsafe {
+            (vt::<IPersistFileVT>(self).Save)(
+                self.ptr(),
+                file_name.map_or(std::ptr::null(), |f| WString::from_str(f).as_ptr()),
+                remember as i32,
+            )
+        })
+    }
+}

--- a/src/ole/com_interfaces/mod.rs
+++ b/src/ole/com_interfaces/mod.rs
@@ -4,6 +4,7 @@ mod idataobject;
 mod idroptarget;
 mod imoniker;
 mod ipersist;
+mod ipersistfile;
 mod ipersiststream;
 mod ipicture;
 mod isequentialstream;
@@ -18,6 +19,7 @@ pub mod decl {
 	pub use super::idroptarget::IDropTarget;
 	pub use super::imoniker::IMoniker;
 	pub use super::ipersist::IPersist;
+	pub use super::ipersistfile::IPersistFile;
 	pub use super::ipersiststream::IPersistStream;
 	pub use super::ipicture::IPicture;
 	pub use super::isequentialstream::ISequentialStream;
@@ -33,6 +35,7 @@ pub mod traits {
 	pub use super::idroptarget::ole_IDropTarget;
 	pub use super::imoniker::ole_IMoniker;
 	pub use super::ipersist::ole_IPersist;
+	pub use super::ipersistfile::ole_IPersistFile;
 	pub use super::ipersiststream::ole_IPersistStream;
 	pub use super::ipicture::ole_IPicture;
 	pub use super::isequentialstream::ole_ISequentialStream;
@@ -48,6 +51,7 @@ pub mod vt {
 	pub use super::idroptarget::IDropTargetVT;
 	pub use super::imoniker::IMonikerVT;
 	pub use super::ipersist::IPersistVT;
+	pub use super::ipersistfile::IPersistFileVT;
 	pub use super::ipersiststream::IPersistStreamVT;
 	pub use super::ipicture::IPictureVT;
 	pub use super::isequentialstream::ISequentialStreamVT;

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -4,6 +4,7 @@ mod com_interfaces;
 mod funcs;
 mod handles;
 mod structs;
+mod utilities;
 
 pub(in crate::shell) mod ffi;
 pub(in crate::shell) mod iterators;
@@ -17,6 +18,7 @@ pub mod decl {
 	pub use super::funcs::*;
 	pub use super::handles::decl::*;
 	pub use super::structs::*;
+	pub use super::utilities::*;
 }
 
 pub mod traits {

--- a/src/shell/utilities/mod.rs
+++ b/src/shell/utilities/mod.rs
@@ -1,0 +1,1 @@
+pub mod shell_lnk;

--- a/src/shell/utilities/shell_lnk.rs
+++ b/src/shell/utilities/shell_lnk.rs
@@ -1,0 +1,119 @@
+use crate::co;
+use crate::decl::*;
+use crate::prelude::*;
+
+pub struct Lnk {
+    me: IShellLink,
+    pf: IPersistFile,
+}
+
+pub trait ShellLinkReadOnly {
+    fn get_arguments(&self) -> HrResult<String>;
+    fn get_description(&self) -> HrResult<String>;
+    fn get_icon_location(&self) -> HrResult<(String, i32)>;
+    fn get_path(&self) -> HrResult<String>;
+    fn get_show_cmd(&self) -> HrResult<co::SW>;
+    fn get_working_directory(&self) -> HrResult<String>;
+}
+
+pub trait ShellLinkWriteOnly {
+    fn set_arguments(&mut self, path: &str) -> HrResult<()>;
+    fn set_description(&mut self, path: &str) -> HrResult<()>;
+    fn set_icon_location(&mut self, path: &str, index: i32) -> HrResult<()>;
+    fn set_path(&mut self, path: &str) -> HrResult<()>;
+    fn set_show_cmd(&mut self, show_cmd: co::SW) -> HrResult<()>;
+    fn set_working_directory(&mut self, path: &str) -> HrResult<()>;
+    fn save(&self) -> HrResult<()>;
+    fn save_as(&self, path: &str) -> HrResult<()>;
+}
+
+impl ShellLinkReadOnly for Lnk {
+    fn get_arguments(&self) -> HrResult<String> {
+        Ok(self.me.GetArguments()?)
+    }
+
+    fn get_description(&self) -> HrResult<String> {
+        Ok(self.me.GetDescription()?)
+    }
+
+    fn get_icon_location(&self) -> HrResult<(String, i32)> {
+        Ok(self.me.GetIconLocation()?)
+    }
+
+    fn get_path(&self) -> HrResult<String> {
+        Ok(self.me.GetPath(None, co::SLGP::UNCPRIORITY)?)
+    }
+
+    fn get_show_cmd(&self) -> HrResult<co::SW> {
+        Ok(self.me.GetShowCmd()?)
+    }
+
+    fn get_working_directory(&self) -> HrResult<String> {
+        Ok(self.me.GetWorkingDirectory()?)
+    }
+}
+
+impl ShellLinkWriteOnly for Lnk {
+    fn set_arguments(&mut self, path: &str) -> HrResult<()> {
+        Ok(self.me.SetArguments(path)?)
+    }
+
+    fn set_description(&mut self, path: &str) -> HrResult<()> {
+        Ok(self.me.SetDescription(path)?)
+    }
+
+    fn set_icon_location(&mut self, path: &str, index: i32) -> HrResult<()> {
+        Ok(self.me.SetIconLocation(path, index)?)
+    }
+
+    fn set_path(&mut self, path: &str) -> HrResult<()> {
+        Ok(self.me.SetPath(path)?)
+    }
+
+    fn set_show_cmd(&mut self, show_cmd: co::SW) -> HrResult<()> {
+        Ok(self.me.SetShowCmd(show_cmd)?)
+    }
+
+    fn set_working_directory(&mut self, path: &str) -> HrResult<()> {
+        Ok(self.me.SetWorkingDirectory(path)?)
+    }
+
+    fn save(&self) -> HrResult<()> {
+        Ok(self.pf.Save(None, true)?)
+    }
+
+    fn save_as(&self, path: &str) -> HrResult<()> {
+        Ok(self.pf.Save(Some(path), true)?)
+    }
+}
+
+pub trait ShellLinkReadWrite: ShellLinkReadOnly + ShellLinkWriteOnly {}
+impl ShellLinkReadWrite for Lnk {}
+
+impl Lnk {
+    pub fn open_read(file_path: &str) -> HrResult<Box<dyn ShellLinkReadOnly>> {
+        let me = CoCreateInstance::<IShellLink>(&co::CLSID::ShellLink, None, co::CLSCTX::INPROC_SERVER)?;
+        let pf = me.QueryInterface::<IPersistFile>()?;
+        pf.Load(file_path, co::STGM::READ)?;
+        let flags = (co::SLR::NO_UI | co::SLR::ANY_MATCH).raw() | (1 << 16);
+        let flags_with_timeout = unsafe { co::SLR::from_raw(flags) };
+        me.Resolve(&HWND::NULL, flags_with_timeout)?;
+        Ok(Box::new(Lnk { me, pf }))
+    }
+
+    pub fn open_write(file_path: &str) -> HrResult<Box<dyn ShellLinkReadWrite>> {
+        let me = CoCreateInstance::<IShellLink>(&co::CLSID::ShellLink, None, co::CLSCTX::INPROC_SERVER)?;
+        let pf = me.QueryInterface::<IPersistFile>()?;
+        pf.Load(file_path, co::STGM::READWRITE)?;
+        let flags = (co::SLR::NO_UI | co::SLR::ANY_MATCH).raw() | (1 << 16);
+        let flags_with_timeout = unsafe { co::SLR::from_raw(flags) };
+        me.Resolve(&HWND::NULL, flags_with_timeout)?;
+        Ok(Box::new(Lnk { me, pf }))
+    }
+
+    pub fn create_new() -> HrResult<Box<dyn ShellLinkReadWrite>> {
+        let me = CoCreateInstance::<IShellLink>(&co::CLSID::ShellLink, None, co::CLSCTX::INPROC_SERVER)?;
+        let pf = me.QueryInterface::<IPersistFile>()?;
+        Ok(Box::new(Lnk { me, pf }))
+    }
+}


### PR DESCRIPTION
**This should not be merged without fixes below.**

I don't really know my way around Rust yet (still learning) or COM (never did), but I tried to add support for IPersistFile with the ultimate goal of being able to create/read shortcuts on windows. 

There are a few rust crates that already try to do this (lnk-rs, mslnk) but they try and achieve this by directly editing .lnk files instead of COM interop. This has advantages and disadvantages. The advantage is, that you can create these files when not on Windows. The disadvantages are many, but overall it is complex, and these libraries are incomplete and have bugs. 

I think it would be advantageous for this library to have an official Microsoft-approved solution to managing shortcuts on windows. 

The implementation was working at one point, but now it does not appear to work. I do not know what I did to break it, and did not have the "working" iteration checked in to source code unfortunately. The problem is a nondescript COM error (either Invalid method or The parameter is incorrect). I believe this is because I have created the IPersistFile VTable incorrectly, but I have tried a bunch of variations and I can't seem to get it working again. 

So I'm leaving this with you. If you can spot the problem and would like me to fix it, I will - otherwise you can fix / merge or just close this. Thanks either way!

Additionally, I would love to add the ability to read and write the AppModelID and ToastActivatorCLSID, but this is more complex. It requires converting the IShellLink to an IPropertyStore and then setting PKEY_AppUserModel_ToastActivatorCLSID or PKEY_AppUserModel_ID to a String PropVariant. Unfortunately, the PropVariant contained in Winsafe does not yet seem to support strings and I was not sure how to add that.