### PR TITLE
Load accelerators from the resource file

### DIFF
--- a/src/gui/windows/raw_main.rs
+++ b/src/gui/windows/raw_main.rs
@@ -207,8 +207,8 @@ pub struct WindowMainOpts {
 	/// [created](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-createwindowexw).
 	/// Use
 	/// [`HACCEL::CreateAcceleratorTable`](crate::prelude::user_Haccel::CreateAcceleratorTable)
-    /// or
-    /// [`HACCEL::LoadAccelerators`](crate::prelude::user_Haccel::LoadAccelerators)
+	/// or
+	/// [`HACCEL::LoadAccelerators`](crate::prelude::user_Haccel::LoadAccelerators)
 	/// to create one.
 	///
 	/// Defaults to `None`.

--- a/src/gui/windows/raw_main.rs
+++ b/src/gui/windows/raw_main.rs
@@ -207,6 +207,8 @@ pub struct WindowMainOpts {
 	/// [created](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-createwindowexw).
 	/// Use
 	/// [`HACCEL::CreateAcceleratorTable`](crate::prelude::user_Haccel::CreateAcceleratorTable)
+    /// or
+    /// [`HACCEL::LoadAccelerators`](crate::prelude::user_Haccel::LoadAccelerators)
 	/// to create one.
 	///
 	/// Defaults to `None`.

--- a/src/user/handles/haccel.rs
+++ b/src/user/handles/haccel.rs
@@ -38,4 +38,14 @@ pub trait user_Haccel: Handle {
 			).map(|h| DestroyAcceleratorTableGuard::new(h))
 		}
 	}
+
+    /// [`LoadAccelerators`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadacceleratorsw)
+    /// function.
+    #[must_use]
+    fn LoadAccelerators(hinst: HINSTANCE, id: IdStr) -> SysResult<DestroyAcceleratorTableGuard> {
+        unsafe {
+            ptr_to_sysresult_handle(ffi::LoadAcceleratorsW(hinst.ptr() as _, id.as_ptr() as _))
+                .map(|h| DestroyAcceleratorTableGuard::new(h))
+        }
+    }
 }

--- a/src/user/handles/haccel.rs
+++ b/src/user/handles/haccel.rs
@@ -39,13 +39,13 @@ pub trait user_Haccel: Handle {
 		}
 	}
 
-    /// [`LoadAccelerators`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadacceleratorsw)
-    /// function.
-    #[must_use]
-    fn LoadAccelerators(hinst: HINSTANCE, id: IdStr) -> SysResult<DestroyAcceleratorTableGuard> {
-        unsafe {
-            ptr_to_sysresult_handle(ffi::LoadAcceleratorsW(hinst.ptr() as _, id.as_ptr() as _))
-                .map(|h| DestroyAcceleratorTableGuard::new(h))
-        }
-    }
+	/// [`LoadAccelerators`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-loadacceleratorsw)
+	/// function.
+	#[must_use]
+	fn LoadAccelerators(hinst: HINSTANCE, id: IdStr) -> SysResult<DestroyAcceleratorTableGuard> {
+		unsafe {
+			ptr_to_sysresult_handle(ffi::LoadAcceleratorsW(hinst.ptr() as _, id.as_ptr() as _))
+				.map(|h| DestroyAcceleratorTableGuard::new(h))
+		}
+	}
 }


### PR DESCRIPTION
Support loading of accelerators from the resource file, rather than manual creation using `CreateAcceleratorTable()`