### PR TITLE
Implement bindings for the `MoveFileEx` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ WinSafe documentation:
 
 | Native FFI item | Count |
 | - | -: |
-| Functions | 798 |
+| Functions | 799 |
 | Structs | 242 |
-| Constants | 13,454 |
+| Constants | 13,459 |
 | Window messages | 655 |
 | Handles | 47 |
 | COM interfaces | 90 |

--- a/src/kernel/co/consts.rs
+++ b/src/kernel/co/consts.rs
@@ -779,6 +779,39 @@ const_ordinary! { MONITOR_DISPLAY_STATE: u32;
 	Dim 2
 }
 
+const_ordinary! { MOVE_FILE_FLAGS: u32;
+	/// [`MoveFileEx`](crate::kernel::funcs::MoveFileEx) `flags` (`u32`).
+	=>
+	/// If the file is being moved to a different filesystem, the function
+	/// will be allowed to simulate the move by copying the file and deleting it.
+	///
+	/// The function succeeds even if the source file cannot be deleted after it
+	/// has been moved.
+	///
+	/// Cannot be combined with `MOVEFILE_DELAY_UNTIL_REBOOT`.
+	MOVEFILE_COPY_ALLOWED 2
+	/// Delays moving the file until the next reboot, just after checking the
+	/// consistency of the root volumes, before user programs are run.
+	///
+	/// This flag can only be used if the process is running with elevated
+	/// privileges.
+	///
+	/// Cannot be combined with `MOVEFILE_COPY_ALLOWED`.
+	MOVEFILE_DELAY_UNTIL_REBOOT 4
+	/// Makes the function fail if the source file is a link source and the file
+	/// cannot be tracked after the move. This can occur if the destination is
+	/// a FAT volume.
+	MOVEFILE_FAIL_IF_NOT_TRACKABLE 32
+	/// If the new file name exists, the function replaces its contents with the
+	/// contents of the source file. Cannot be used when the source file is an
+	/// existing directory.
+	MOVEFILE_REPLACE_EXISTING 1
+	/// Waits until the file is actually moved on the disk before returning.
+	///
+	/// Has no effect if `MOVEFILE_DELAY_UNTIL_REBOOT` is set.
+	MOVEFILE_WRITE_THROUGH 8
+}
+
 const_ordinary! { PAGE: u32;
 	/// [`HFILE::CreateFileMapping`](crate::prelude::kernel_Hfile::CreateFileMapping)
 	/// `protect` (`u32`).

--- a/src/kernel/ffi.rs
+++ b/src/kernel/ffi.rs
@@ -136,6 +136,7 @@ extern_sys! { "kernel32";
 	Module32FirstW(HANDLE, PVOID) -> BOOL
 	Module32NextW(HANDLE, PVOID) -> BOOL
 	MoveFileW(PCSTR, PCSTR) -> BOOL
+	MoveFileExW(PCSTR, PCSTR, u32) -> BOOL
 	MulDiv(i32, i32, i32) -> i32
 	MultiByteToWideChar(u32, u32, *const u8, i32, PSTR, i32) -> i32
 	OpenEventW(u32, BOOL, PCSTR) -> HANDLE

--- a/src/kernel/funcs.rs
+++ b/src/kernel/funcs.rs
@@ -13,6 +13,7 @@ use crate::prelude::*;
 ///
 /// * [`DeleteFile`](crate::DeleteFile)
 /// * [`MoveFile`](crate::MoveFile)
+/// * [`MoveFileEx`](crate::MoveFileEx)
 /// * [`ReplaceFile`](crate::ReplaceFile)
 pub fn CopyFile(
 	existing_file: &str,
@@ -55,6 +56,7 @@ pub fn CreateDirectory(
 ///
 /// * [`CopyFile`](crate::CopyFile)
 /// * [`MoveFile`](crate::MoveFile)
+/// * [`MoveFileEx`](crate::MoveFileEx)
 /// * [`ReplaceFile`](crate::ReplaceFile)
 pub fn DeleteFile(file_name: &str) -> SysResult<()> {
 	bool_to_sysresult(
@@ -1161,6 +1163,7 @@ pub const fn MAKEWORD(lo: u8, hi: u8) -> u16 {
 ///
 /// # Related functions
 ///
+/// * [`MoveFileEx`](crate::MoveFileEx)
 /// * [`CopyFile`](crate::CopyFile)
 /// * [`DeleteFile`](crate::DeleteFile)
 /// * [`ReplaceFile`](crate::ReplaceFile)
@@ -1170,6 +1173,27 @@ pub fn MoveFile(existing_file: &str, new_file: &str) -> SysResult<()> {
 			ffi::MoveFileW(
 				WString::from_str(existing_file).as_ptr(),
 				WString::from_str(new_file).as_ptr(),
+			)
+		},
+	)
+}
+
+/// [`MoveFileEx`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw)
+/// function.
+///
+/// # Related functions
+///
+/// * [`MoveFile`](crate::MoveFile)
+/// * [`CopyFile`](crate::CopyFile)
+/// * [`DeleteFile`](crate::DeleteFile)
+/// * [`ReplaceFile`](crate::ReplaceFile)
+pub fn MoveFileEx(existing_file: &str, new_file: Option<&str>, flags: co::MOVE_FILE_FLAGS) -> SysResult<()> {
+	bool_to_sysresult(
+		unsafe {
+			ffi::MoveFileExW(
+				WString::from_str(existing_file).as_ptr(),
+				WString::from_opt_str(new_file).as_ptr(),
+				flags.raw(),
 			)
 		},
 	)


### PR DESCRIPTION
This is a bit of a lesser-known Win32 API function that nevertheless offers the powerful feature of scheduling files for deletion on the next boot, which is so useful for implementing file cleanup code, and temporary files that are guaranteed to last for a single boot.