### PR TITLE
Fix linking errors for `GetCurrentProcessToken` and `GetCurrentThreadEffectiveToken`

### DIFF
--- a/src/advapi/ffi.rs
+++ b/src/advapi/ffi.rs
@@ -21,8 +21,6 @@ extern_sys! { "advapi32";
 	EqualPrefixSid(PVOID, PVOID) -> BOOL
 	EqualSid(PVOID, PVOID) -> BOOL
 	FreeSid(PVOID)
-	GetCurrentProcessToken() -> HANDLE
-	GetCurrentThreadEffectiveToken() -> HANDLE
 	GetLengthSid(PVOID) -> u32
 	GetSidLengthRequired(u8) -> u32
 	GetTokenInformation(HANDLE, u32, PCVOID, u32, *mut u32) -> BOOL

--- a/src/advapi/handles/haccesstoken.rs
+++ b/src/advapi/handles/haccesstoken.rs
@@ -123,14 +123,20 @@ pub trait advapi_Haccesstoken: Handle {
 	/// function.
 	#[must_use]
 	fn GetCurrentProcessToken() -> HACCESSTOKEN {
-		HACCESSTOKEN(unsafe { ffi::GetCurrentProcessToken() })
+		// We don't do a FFI call because there's no actual library function to call: this is an
+		// inlined function defined in the processthreadsapi.h header that always returns a constant.
+		// See: https://github.com/microsoft/win32metadata/issues/436
+		HACCESSTOKEN(-4 as _)
 	}
 
 	/// [`GetCurrentThreadEffectiveToken`](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getcurrentthreadeffectivetoken)
 	/// function.
 	#[must_use]
 	fn GetCurrentThreadEffectiveToken() -> HACCESSTOKEN {
-		HACCESSTOKEN(unsafe { ffi::GetCurrentThreadEffectiveToken() })
+		// We don't do a FFI call because there's no actual library function to call: this is an
+		// inlined function defined in the processthreadsapi.h header that always returns a constant.
+		// See: https://github.com/microsoft/win32metadata/issues/436
+		HACCESSTOKEN(-6 as _)
 	}
 
 	/// [`GetTokenInformation`](https://learn.microsoft.com/en-us/windows/win32/api/securitybaseapi/nf-securitybaseapi-gettokeninformation)


### PR DESCRIPTION
The aforementioned functions are defined with the `FORCEINLINE` attribute in the `processthreadsapi.h` header and always return a constant value, preventing C/C++ compilers from generating actual function calls for them. Consequently, these functions are not exported by `advapi32.dll`, which leads to linkage errors on probably any Windows toolchain if a project depending on `winsafe` tries to use them (I specifically encountered this issue while working with a MinGW toolchain):

![advapi32.dll lacking the referenced functions](https://github.com/user-attachments/assets/96905ff0-433b-486e-9eed-01dd223b7fa2)

To make these functions usable, let's replicate the behavior of the inlined header functions, avoiding emitting any FFI calls.

References:

- https://github.com/microsoft/win32metadata/issues/436
- https://github.com/microsoft/windows-rs/issues/2935
- https://github.com/mirror/mingw-w64/blob/93f3505a758fe70e56678f00e753af3bc4f640bb/mingw-w64-headers/include/processthreadsapi.h#L245-L256