### PR TITLE
fix for panic on DateTimePicker::set_date

### DIFF
--- a/src/comctl/messages/dtm.rs
+++ b/src/comctl/messages/dtm.rs
@@ -294,8 +294,8 @@ impl<'a> MsgSend for SetSystemTime<'a> {
 	fn as_generic_wm(&mut self) -> WndMsg {
 		WndMsg {
 			msg_id: co::DTM::SETSYSTEMTIME.into(),
-			wparam: self.system_time.as_ref().map_or(co::GDT::NONE.raw(), |_| co::GDT::VALID.raw()) as _,
-			lparam: self.system_time.as_ref().map_or(0, |st| st as *const _ as _),
+			wparam: self.system_time.map_or(co::GDT::NONE.raw(), |_| co::GDT::VALID.raw()) as _,
+			lparam: self.system_time.map_or(0, |st| st as *const _ as _),
 		}
 	}
 }


### PR DESCRIPTION
`DateTimePicker::set_date` always panics. While investigating this issue I noticed that the `SetSystemTime` implementation creates a pointer to a reference, which gets falsely passed to the system.