### PR TITLE
Add some additional functions and structures

### DIFF
--- a/src/kernel/enums.rs
+++ b/src/kernel/enums.rs
@@ -98,6 +98,50 @@ impl IdStr {
 }
 
 /// Variant parameter for:
+/// 
+/// * [`MEMORY_BASIC_INFORMATION`](crate::MEMORY_BASIC_INFORMATION).
+#[repr(C)]
+pub enum MemoryBasicInformationAllocationProtect {
+	None = 0,
+
+	Execute = 0x10,
+	ExecuteRead = 0x20,
+	ExecuteReadWrite = 0x40,
+	ExecuteWriteCopy = 0x80,
+	NoAccess = 0x01,
+	ReadOnly = 0x02,
+	ReadWrite = 0x04,
+	WriteCopy = 0x08,
+	TargetsInvalidOrNoUpdate = 0x40000000,
+
+	Guard = 0x100,
+	NoCache = 0x200,
+	WriteCombine = 0x400,
+}
+
+/// Variant parameter for:
+/// 
+/// * [`MEMORY_BASIC_INFORMATION`](crate::MEMORY_BASIC_INFORMATION).
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum MemoryBasicInformationState {
+	Commit = 0x1000,
+	Free = 0x10000,
+	Reverse = 0x2000
+}
+
+/// Variant parameter for:
+/// 
+/// * [`MEMORY_BASIC_INFORMATION`](crate::MEMORY_BASIC_INFORMATION).
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(C)]
+pub enum MemoryBasicInformationType {
+	Image = 0x1000000,
+	Mapped = 0x40000,
+	Private = 0x20000,
+}
+
+/// Variant parameter for:
 ///
 /// * [`POWERBROADCAST_SETTING`](crate::POWERBROADCAST_SETTING).
 pub enum PowerSetting {

--- a/src/kernel/ffi.rs
+++ b/src/kernel/ffi.rs
@@ -156,6 +156,7 @@ extern_sys! { "kernel32";
 	QueryUnbiasedInterruptTime(&mut u64) -> BOOL
 	ReadConsoleW(HANDLE, PVOID, u32, *mut u32, PCVOID) -> BOOL
 	ReadFile(HANDLE, PVOID, u32, *mut u32, PVOID) -> BOOL
+	ReadProcessMemory(HANDLE, PCVOID, PCVOID, usize, *mut usize) -> BOOL
 	ReplaceFileW(PCSTR, PCSTR, PCSTR, u32, PVOID, PVOID) -> BOOL
 	ResetEvent(HANDLE) -> BOOL
 	ResumeThread(HANDLE) -> u32
@@ -189,6 +190,7 @@ extern_sys! { "kernel32";
 	UpdateResourceW(HANDLE, PCSTR, PCSTR, u16, PVOID, u32) -> BOOL
 	VerifyVersionInfoW(PVOID, u32, u64) -> BOOL
 	VerSetConditionMask(u64, u32, u8) -> u64
+	VirtualQueryEx(HANDLE, PCVOID, *mut crate::MEMORY_BASIC_INFORMATION, usize) -> usize
 	WaitForSingleObject(HANDLE, u32) -> u32
 	WideCharToMultiByte(u32, u32, PCSTR, i32, PSTR, i32, *const u8, *mut BOOL) -> i32
 	WriteConsoleW(HANDLE, PCVOID, u32, *mut u32, PVOID) -> BOOL

--- a/src/kernel/handles/hmodule.rs
+++ b/src/kernel/handles/hmodule.rs
@@ -1,0 +1,23 @@
+#![allow(non_camel_case_types, non_snake_case)]
+
+use crate::prelude::*;
+
+handle! { HMODULE;
+	/// Handle to a
+	/// module.
+	/// Originally just a `HANDLE`.
+}
+
+impl kernel_Hmodule for HMODULE {}
+
+/// This trait is enabled with the `kernel` feature, and provides methods for
+/// [`HMODULE`](crate::HMODULE).
+///
+/// Prefer importing this trait through the prelude:
+///
+/// ```no_run
+/// use winsafe::prelude::*;
+/// ```
+pub trait kernel_Hmodule: Handle {
+    
+}

--- a/src/kernel/handles/mod.rs
+++ b/src/kernel/handles/mod.rs
@@ -8,6 +8,7 @@ mod hglobal;
 mod hheap;
 mod hinstance;
 mod hlocal;
+mod hmodule;
 mod hpipe;
 mod hprocess;
 mod hprocesslist;
@@ -25,6 +26,7 @@ pub mod decl {
 	pub use super::hheap::HHEAP;
 	pub use super::hinstance::HINSTANCE;
 	pub use super::hlocal::HLOCAL;
+	pub use super::hmodule::HMODULE;
 	pub use super::hpipe::HPIPE;
 	pub use super::hprocess::HPROCESS;
 	pub use super::hprocesslist::HPROCESSLIST;
@@ -62,6 +64,7 @@ pub mod traits {
 	pub use super::hheap::kernel_Hheap;
 	pub use super::hinstance::kernel_Hinstance;
 	pub use super::hlocal::kernel_Hlocal;
+	pub use super::hmodule::kernel_Hmodule;
 	pub use super::hpipe::kernel_Hpipe;
 	pub use super::hprocess::kernel_Hprocess;
 	pub use super::hprocesslist::kernel_Hprocesslist;

--- a/src/kernel/structs/structs_other.rs
+++ b/src/kernel/structs/structs_other.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use crate::co;
 use crate::decl::*;
-use crate::kernel::privs::*;
+use crate::kernel::{ffi_types::*, privs::*};
 
 /// [`ACL`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-acl)
 /// struct.
@@ -429,6 +429,22 @@ impl LUID {
 		self.HighPart
 	}
 }
+
+/// [`MEMORY_BASIC_INFORMATION`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-memory_basic_information)
+/// struct.
+#[repr(C)]
+pub struct MEMORY_BASIC_INFORMATION {
+	pub BaseAddress: PVOID,
+	pub AllocationBase: PVOID,
+	pub AllocationProtect: MemoryBasicInformationAllocationProtect,
+	pub PartitionId: u16,
+	pub RegionSize: usize,
+	pub State: MemoryBasicInformationState,
+	pub Protect: MemoryBasicInformationAllocationProtect,
+	pub Type: MemoryBasicInformationType,
+}
+
+impl_default!(MEMORY_BASIC_INFORMATION);
 
 /// [`MODULEENTRY32`](https://learn.microsoft.com/en-us/windows/win32/api/tlhelp32/ns-tlhelp32-moduleentry32w)
 /// struct.

--- a/src/psapi/ffi.rs
+++ b/src/psapi/ffi.rs
@@ -2,4 +2,7 @@ use crate::kernel::ffi_types::*;
 
 extern_sys! { "psapi";
 	GetProcessMemoryInfo(HANDLE, PVOID, u32) -> BOOL
+	EnumProcessModules(HANDLE, *mut *mut HANDLE, u32, *const u32) -> BOOL
+	GetModuleBaseNameA(HANDLE, HANDLE, PSTR, u32) -> u32
+	GetModuleInformation(HANDLE, HANDLE, *mut crate::MODULEINFO, u32) -> BOOL
 }

--- a/src/psapi/handles/hmodule.rs
+++ b/src/psapi/handles/hmodule.rs
@@ -1,0 +1,18 @@
+#![allow(non_camel_case_types, non_snake_case)]
+
+use crate::decl::*;
+use crate::prelude::*;
+
+impl psapi_Hmodule for HMODULE {}
+
+/// This trait is enabled with the `psapi` feature, and provides methods for
+/// [`HMODULE`](crate::HMODULE).
+///
+/// Prefer importing this trait through the prelude:
+///
+/// ```no_run
+/// use winsafe::prelude::*;
+/// ```
+pub trait psapi_Hmodule: kernel_Hmodule {
+
+}

--- a/src/psapi/handles/hprocess.rs
+++ b/src/psapi/handles/hprocess.rs
@@ -29,4 +29,64 @@ pub trait psapi_Hprocess: kernel_Hprocess {
 		})
 		.map(|_| pmc)
 	}
+
+	/// [`EnumProcessModules`](https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-enumprocessmodules)
+	/// function.
+	#[must_use]
+	fn EnumProcessModules(
+		&self,
+		hmodule_buffer: &mut [HMODULE],
+	) -> SysResult<u32> {
+		let mut cb_needed = 0_u32;
+		bool_to_sysresult(unsafe {
+			ffi::EnumProcessModules(
+				self.ptr(),
+				hmodule_buffer.as_mut_ptr() as _,
+				hmodule_buffer.len() as _,
+				&mut cb_needed
+			)
+		})
+		.map(|_| cb_needed)
+	}
+
+	/// [`GetModuleBaseNameA`](https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmodulebasenamea)
+	/// function.
+	#[must_use]
+	fn GetModuleBaseNameA(
+		&self,
+		hmodule: Option<HMODULE>,
+		sz: usize,
+	) -> SysResult<WString> {
+		let mut buf = WString::new_alloc_buf(sz);
+		unsafe {
+			ffi::GetModuleBaseNameA(
+				self.ptr(),
+				hmodule.map(|x| x.ptr()).unwrap_or_else(std::ptr::null_mut),
+				buf.as_mut_ptr(),
+				buf.buf_len() as u32,
+			)
+		}
+			.eq(&0)
+			.then(|| buf)
+			.ok_or_else(GetLastError)
+	}
+
+	/// [`GetModuleInformation`](https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmoduleinformation)
+    /// function.
+    #[must_use]
+    fn GetModuleInformation(
+		&self,
+		hmodule: HMODULE,
+	) -> SysResult<MODULEINFO> {
+		let mut mod_info = MODULEINFO::default();
+		bool_to_sysresult(unsafe {
+			ffi::GetModuleInformation(
+				self.ptr(),
+				hmodule.ptr(),
+				&mut mod_info,
+				std::mem::size_of::<MODULEINFO>() as u32,
+			)
+		})
+		.map(|_| mod_info)
+    }
 }

--- a/src/psapi/handles/mod.rs
+++ b/src/psapi/handles/mod.rs
@@ -1,5 +1,7 @@
+mod hmodule;
 mod hprocess;
 
 pub mod traits {
+	pub use super::hmodule::psapi_Hmodule;
 	pub use super::hprocess::psapi_Hprocess;
 }

--- a/src/psapi/structs.rs
+++ b/src/psapi/structs.rs
@@ -1,5 +1,7 @@
 #![allow(non_camel_case_types, non_snake_case)]
 
+use crate::kernel::ffi_types::*;
+
 /// [`PROCESS_MEMORY_COUNTERS_EX`](https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-process_memory_counters_ex)
 /// struct.
 #[repr(C)]
@@ -18,3 +20,14 @@ pub struct PROCESS_MEMORY_COUNTERS_EX {
 }
 
 impl_default!(PROCESS_MEMORY_COUNTERS_EX, cb);
+
+/// [`MODULEINFO`](https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-moduleinfo)
+/// struct.
+#[repr(C)]
+pub struct MODULEINFO {
+	pub lpBaseOfDll: PVOID,
+	pub SizeOfImage: u32,
+	pub EntryPoint: PVOID,
+}
+
+impl_default!(MODULEINFO);


### PR DESCRIPTION
I added some functions I needed, find a list of the additions below:

## Traits

- `kernel_Hmodule`
- `psapi_Hmodule` (redundant, but may be used in future)

## Methods

- [`ReadProcessMemory`](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-readprocessmemory)
- [`VirtualQueryEx`](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualqueryex)
- [`EnumProcessModules`](https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-enumprocessmodules)
- [`GetModuleBaseNameA`](https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmodulebasenamea)
- [`GetModuleInformation`](https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getmoduleinformation)

# Enums

- `MemoryBasicInformationAllocationProtect`
- `MemoryBasicInformationState`
- `MemoryBasicInformationType`

# Structs

- [`MEMORY_BASIC_INFORMATION`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-memory_basic_information)
- [`MODULEINFO`](https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-moduleinfo)