### PR TITLE
Update edit.rs

### DIFF
--- a/src/gui/native_controls/edit.rs
+++ b/src/gui/native_controls/edit.rs
@@ -192,7 +192,14 @@ impl Edit {
 		self.hwnd().SetWindowText(text)?;
 		Ok(())
 	}
-
+	/// replacement of text at the current selection/caret position.
+	pub fn replace_sel(&self, text: &str) {
+		let ws = winsafe::WString::from_str(text);
+		unsafe { log.hwnd().SendMessage(em::ReplaceSel{
+			can_be_undone: false,
+			replacement_text: ws,
+		}) }
+	}
 	/// Displays a balloon tip by sending an
 	/// [`em::ShowBalloonTip`](crate::msg::em::ShowBalloonTip) message.
 	pub fn show_ballon_tip(&self, title: &str, text: &str, icon: co::TTI) -> SysResult<()> {
@@ -291,3 +298,4 @@ impl<'a> Default for EditOpts<'a> {
 		}
 	}
 }
+


### PR DESCRIPTION
### Add `replace_sel` method to Edit control

This PR adds the `replace_sel` method to the `Edit` control, enabling efficient insertion or replacement of text at the current selection/caret position.

#### Summary
The `replace_sel` method provides a way to insert new text into an `Edit` control without replacing the entire content. This is particularly useful for:
*   **Appending log messages** to a multi-line text box.
*   Implementing rich text editors or input fields with dynamic content updates.
*   Any scenario requiring incremental text updates.

Instead of using `set_text`, which can be inefficient and cause flickering for large texts, `replace_sel` directly modifies the selected range (or inserts at the caret if no selection), offering better performance and user experience.

#### Usage Example
```rust
let edit = /* obtain Edit control */;
edit.set_selection(-1, 0); // Move caret to end
edit.replace_sel("New log entry\r\n")?; // Insert text at caret
```

#### Implementation Details
*   The method wraps the Windows API message `EM_REPLACESEL`.
*   It takes a string slice (`&str`) as input and sends it to the underlying `HWND`.

This addition fills a common gap in GUI development and aligns with standard Windows edit control functionality.

---