### PR TITLE
update edit.rs

### DIFF
--- a/src/gui/native_controls/edit.rs
+++ b/src/gui/native_controls/edit.rs
@@ -152,6 +152,18 @@ impl Edit {
 		}
 	}
 
+	/// Replaces the currently selected text by sending an
+	/// [`em::ReplaceSel`](crate::msg::em::ReplaceSel) message.
+	pub fn replace_selection(&self, text: &str) {
+		let text16 = WString::from_str(text);
+		unsafe {
+			self.hwnd().SendMessage(em::ReplaceSel {
+				can_be_undone: true,
+				replacement_text: text16,
+			})
+		}
+	}
+
 	/// Sets the selection range of the text by sending an
 	/// [`em::SetSel`](crate::msg::em::SetSel) message.
 	///
@@ -192,14 +204,7 @@ impl Edit {
 		self.hwnd().SetWindowText(text)?;
 		Ok(())
 	}
-	/// replacement of text at the current selection/caret position.
-	pub fn replace_sel(&self, text: &str) {
-		let ws = WString::from_str(text);
-		unsafe { log.hwnd().SendMessage(em::ReplaceSel{
-			can_be_undone: false,
-			replacement_text: ws,
-		}) }
-	}
+
 	/// Displays a balloon tip by sending an
 	/// [`em::ShowBalloonTip`](crate::msg::em::ShowBalloonTip) message.
 	pub fn show_ballon_tip(&self, title: &str, text: &str, icon: co::TTI) -> SysResult<()> {
@@ -298,5 +303,3 @@ impl<'a> Default for EditOpts<'a> {
 		}
 	}
 }
-
-


### PR DESCRIPTION
Here's a professional pull request (PR) description in English for your `replace_sel` method implementation:

---

### Add `replace_sel` method to Edit control

This PR adds the `replace_sel` method to the `Edit` control, enabling efficient insertion or replacement of text at the current selection/caret position.

#### Summary
The `replace_sel` method provides a way to insert new text into an `Edit` control without replacing the entire content. This is particularly useful for:
*   **Appending log messages** to a multi-line text box.
*   Implementing rich text editors or input fields with dynamic content updates.
*   Any scenario requiring incremental text updates.

Instead of using `set_text`, which can be inefficient and cause flickering for large texts, `replace_sel` directly modifies the selected range (or inserts at the caret if no selection), offering better performance and user experience.

#### Usage Example
```rust
let edit = /* obtain Edit control */;
edit.set_selection(-1, 0); // Move caret to end
edit.replace_sel("New log entry\r\n")?; // Insert text at caret

```

#### Implementation Details
*   The method wraps the Windows API message `EM_REPLACESEL`.
*   It takes a string slice (`&str`) as input and sends it to the underlying `HWND`.

This addition fills a common gap in GUI development and aligns with standard Windows edit control functionality.

---