### PR TITLE
Correct GetTokenInformation Error handling.

### DIFF
--- a/src/advapi/handles/haccesstoken.rs
+++ b/src/advapi/handles/haccesstoken.rs
@@ -160,7 +160,8 @@ impl HACCESSTOKEN {
 		.to_sysresult()
 		{
 			Err(err) => match err {
-				co::ERROR::INSUFFICIENT_BUFFER => {}, // all good
+				// NOTE: Some TOKEN_INFORMATION_CLASS (e.g. Elevation) return BAD_LENGTH
+				co::ERROR::INSUFFICIENT_BUFFER | co::ERROR::BAD_LENGTH => {}, // all good
 				err => return Err(err),
 			},
 			Ok(_) => return Err(co::ERROR::INVALID_PARAMETER), // should never happen


### PR DESCRIPTION
Based on IDA's analysis of NtQueryInformationToken and some documents, TokenElevation returns ERROR_BAD_LENGTH (24), which corresponds to NTSTATUS STATUS_INFO_LENGTH_MISMATCH (0xC0000004)

<img width="1171" height="369" alt="7cc9cdffaaeb5231447f2218298e1d42" src="https://github.com/user-attachments/assets/6491608f-84a4-4927-9d2d-19080d642577" />

External document: https://ntdoc.m417z.com/ntqueryinformationtoken#notable-return-values
